### PR TITLE
Bluetooth: Ensure to release wake lock during turn off

### DIFF
--- a/osi/src/wakelock.cc
+++ b/osi/src/wakelock.cc
@@ -213,6 +213,10 @@ static void wakelock_initialize_native(void) {
 }
 
 void wakelock_cleanup(void) {
+  if (wakelock_stats.is_acquired) {
+    LOG_ERROR(LOG_TAG, "%s releasing wake lock as part of cleanup", __func__);
+    wakelock_release();
+  }
   wake_lock_path.clear();
   wake_unlock_path.clear();
   initialized = PTHREAD_ONCE_INIT;


### PR DESCRIPTION
- Timers running with less than 3 seconds will acquire
  wake lock internally.

- This patch ensures to release wake lock as part of
  turn off procedure if any module has not stopped
  timers properly.

CRs-Fixed: 2310057
Change-Id: I384dfc47d2e57371066efd370bbdca36e5910eb4